### PR TITLE
Added a missing breakpoints to options

### DIFF
--- a/src/components/Glide.vue
+++ b/src/components/Glide.vue
@@ -199,6 +199,7 @@ export default {
         animationTimingFunc: this.animationTimingFunc,
         direction: this.direction,
         peek: this.peek,
+        breakpoints: this.breakpoints,
         classes: Object.assign(defaultClasses, this.classes),
         throttle: this.throttle
       }


### PR DESCRIPTION
Hi!

I couldn't make the breakpoints work through props so I took a look at your source and discovered that breakpoints were not added to the options for Glide. What do you think?