### PR TITLE
Fix: avoid click event twice if we have nested tag inside <glide-slide>

### DIFF
--- a/src/components/Glide.js
+++ b/src/components/Glide.js
@@ -292,8 +292,10 @@ export default {
           if (!e.target.classList.contains('glide__slide')) {
             recursive(e.target)
           }
+          else{
+            this.$emit('glide:slide-click', Number(e.target.dataset.glideIndex))
+          }
 
-          this.$emit('glide:slide-click', Number(e.target.dataset.glideIndex))
         })
       })
     },


### PR DESCRIPTION
Source code: 
<template>
  <div id="app">
    <h1>Workbench</h1>
    <vue-glide class="demo" :bullet="true" @glide:slide-click="test">
      <vue-glide-slide
        v-for="i in 10"
        :key="i">
        <div>Slide {{ i }}</div>
      </vue-glide-slide>
    </vue-glide>
  </div>
</template>
<script>
import VueGlide from './components/Glide'
import VueGlideSlide from './components/GlideSlide'

export default {
  components: {
    [VueGlide.name]: VueGlide,
    [VueGlideSlide.name]: VueGlideSlide
  },
  methods:{
    test(num) {
      console.log(num)
    }
  }
}
</script>

Operation:
Click first item

Expected log:
0
Actual log:
0
NaN

Reason:
$Emit should not be invoked if recursive is succeed.